### PR TITLE
ENYO-6491 & ENYO-6492: CLI-based ESLint plugins/parser not always resolved correctly

### DIFF
--- a/get-config.js
+++ b/get-config.js
@@ -2,8 +2,19 @@ const fs = require('fs');
 const path = require('path');
 const {npmGlobalModules, yarnGlobalModules, supportGlobalResolving} = require('./global-resolver');
 
+// Find first parent module from the accessing ESLint.
+const parentOf = m => Object.values(require.cache).filter(c => c.children.includes(m))[0];
+const eslintParent = parentOf(parentOf(module));
+
+// Detect NPM and Yarn global node_modules locations and attempt to find an active entry.
 const globalPaths = [npmGlobalModules(), yarnGlobalModules()].filter(Boolean);
-const defaultSearch = globalPaths
+const activeGlobalPath = globalPaths.find(d =>
+	eslintParent.path.startsWith(fs.realpathSync(path.dirname(d)))
+);
+
+// Use base global node_modules location and <global>/@enact/cli/node_modules as the default
+// search locations.
+const defaultSearch = (activeGlobalPath ? [activeGlobalPath] : globalPaths)
 	.reduce((acc, dir) => (acc.concat(dir, path.join(dir, '@enact', 'cli', 'node_modules'))), [])
 	.filter(dir => fs.existsSync(dir));
 
@@ -12,8 +23,8 @@ function getGlobalConfig({
 		ruleset = 'enact'
 	} = {}
 ) {
-	// Locate ESLint module resolver file
-	const eslintResolverPath = globalPaths
+	// Locate ESLint module resolver file.
+	const eslintResolverPath = search
 		.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
 		.find(dir => fs.existsSync(dir));
 	if (eslintResolverPath) {

--- a/get-config.js
+++ b/get-config.js
@@ -2,35 +2,28 @@ const fs = require('fs');
 const path = require('path');
 const {npmGlobalModules, yarnGlobalModules, supportGlobalResolving} = require('./global-resolver');
 
-const globalModulesPath = npmGlobalModules() || yarnGlobalModules() || '';
+const globalPaths = [npmGlobalModules(), yarnGlobalModules()].filter(Boolean);
+const defaultSearch = globalPaths
+	.reduce((acc, dir) => (acc.concat(dir, path.join(dir, '@enact', 'cli', 'node_modules'))), [])
+	.filter(dir => fs.existsSync(dir));
 
 function getGlobalConfig({
-		search = [
-			globalModulesPath,
-			path.join(globalModulesPath, '@enact', 'cli', 'node_modules')
-		],
+		search = defaultSearch,
 		ruleset = 'enact'
 	} = {}
 ) {
-	if (globalModulesPath) {
-		// Locate ESLint root package level from active main module
-		const eslintPath = path.join(globalModulesPath, 'eslint')
-
-
-		// ESLint's module resolver file
-		const resolverFile = path.join(eslintPath, 'lib', 'shared', 'relative-module-resolver.js');
-
-		if (fs.existsSync(resolverFile)) {
-			// Find first global search path containing eslint-config-enact
-			const dir = search.find(d => fs.existsSync(path.join(d, 'eslint-config-enact')));
-			if (dir) supportGlobalResolving(resolverFile, dir);
-		}
-		// If eslint/lib/shared/relative-module-resolver.js does not exist, then
-		// our global resolving support cannot be patched in.
-		// As a meaningful fallback, and to backward-support ESLint <=5.x, still
-		// should extend the desired ruleset.
-		return {extends: ruleset};
+	// Locate ESLint module resolver file
+	const eslintResolverPath = globalPaths
+		.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
+		.find(dir => fs.existsSync(dir));
+	if (eslintResolverPath) {
+		supportGlobalResolving(eslintResolverPath, search);
 	}
+	// If eslint/lib/shared/relative-module-resolver.js does not exist, then
+	// our global resolving support cannot be patched in.
+	// As a meaningful fallback, and to backward-support ESLint <=5.x, still
+	// should extend the desired ruleset.
+	return {extends: ruleset};
 }
 
 module.exports = {


### PR DESCRIPTION
* Altered the resolver override to attempt fallback module requests for each potential global search location (global root + global Enact CLI, in that priority). This allows people to symlink local git clones of Enact config and/or Enact plugin with everything absent being sourced from Enact CLI. Mixing and matching global root + CLI is not recommened, but it solves certain edge-cases.
* Additionally, fixed Yarn support, so Yarn-based global locations are now handled (before the mere presence  of NPM was causing Yarn support to be skipped over). Now Yarn-based locations are included in the list of default valid global locations.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>