### PR TITLE
PLAT-136881: Fix in-editor linting is not working with the latest eslint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact proxy ESLint config:
 
+## [unreleased]
+
+### Fixed
+
+- Change Locates of ESLint module resolver file.
+
 ## [1.0.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact proxy ESLint config:
 
 ### Fixed
 
-- Change Locations of ESLint module resolver file.
+- ESLint module resolver path to resolve correctly with the latest eslint.
 
 ## [1.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following is a curated list of changes in the Enact proxy ESLint config:
 
 ### Fixed
 
-- Change Locates of ESLint module resolver file.
+- Change Locations of ESLint module resolver file.
 
 ## [1.0.1]
 

--- a/get-config.js
+++ b/get-config.js
@@ -24,10 +24,10 @@ function getGlobalConfig({
 	} = {}
 ) {
 	// Locate ESLint module resolver file.
-	let eslintResolverPathArr = search.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js'));
-	eslintResolverPathArr.push(...search.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js')));
-
-	const eslintResolverPath = eslintResolverPathArr.find(dir => fs.existsSync(dir));
+	const eslintResolverPath = [
+		...search.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js')),
+		...search.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
+	].find(dir => fs.existsSync(dir));
 	if (eslintResolverPath) {
 		supportGlobalResolving(eslintResolverPath, search);
 	}

--- a/get-config.js
+++ b/get-config.js
@@ -24,16 +24,10 @@ function getGlobalConfig({
 	} = {}
 ) {
 	// Locate ESLint module resolver file.
-	let eslintResolverPath = search
-	.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js'))
-	.find(dir => fs.existsSync(dir));
-	if (!eslintResolverPath) {
-		// Locate ESLint module resolver file.(< 7.12.0)
-		eslintResolverPath = search
-		.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
-		.find(dir => fs.existsSync(dir));
-	}
+	let eslintResolverPathArr = search.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js'));
+	eslintResolverPathArr.push(...search.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js')));
 
+	const eslintResolverPath = eslintResolverPathArr.find(dir => fs.existsSync(dir));
 	if (eslintResolverPath) {
 		supportGlobalResolving(eslintResolverPath, search);
 	}

--- a/get-config.js
+++ b/get-config.js
@@ -24,9 +24,16 @@ function getGlobalConfig({
 	} = {}
 ) {
 	// Locate ESLint module resolver file.
-	const eslintResolverPath = search
-		.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js'))
+	let eslintResolverPath = search
+	.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js'))
+	.find(dir => fs.existsSync(dir));
+	if (!eslintResolverPath) {
+		// Locate ESLint module resolver file.(< 7.12.0)
+		eslintResolverPath = search
+		.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
 		.find(dir => fs.existsSync(dir));
+	}
+
 	if (eslintResolverPath) {
 		supportGlobalResolving(eslintResolverPath, search);
 	}

--- a/get-config.js
+++ b/get-config.js
@@ -25,7 +25,7 @@ function getGlobalConfig({
 ) {
 	// Locate ESLint module resolver file.
 	const eslintResolverPath = search
-		.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
+		.map(dir => path.join(dir, 'eslint', 'node_modules', '@eslint', 'eslintrc', 'lib', 'shared', 'relative-module-resolver.js'))
 		.find(dir => fs.existsSync(dir));
 	if (eslintResolverPath) {
 		supportGlobalResolving(eslintResolverPath, search);


### PR DESCRIPTION
### Issue Resolved / Feature Added
Failed to load config in the latest ESLint version due to the matched function had been moved to the legacy repo.

### Resolution
Added changed eslintResolverPath from eslintrc(legacy) repo

### Additional Considerations

### Links
PLAT-136881

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)