### PR TITLE
WRN-12748: Fix fail to load config in the latest ESLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The following is a curated list of changes in the Enact proxy ESLint config:
 
+## [unreleased]
+
+### Fixed
+
+- Applied the new API to call ESLint module resolver correctly with the latest eslint.
+
 ## [1.0.3] (December 28, 2021)
 
 No significant changes.

--- a/get-config.js
+++ b/get-config.js
@@ -42,7 +42,7 @@ function getGlobalConfig({
 					}
 				} = require(eslintrcPath);
 				eslintResolver = ModuleResolver;
-			} else if (semver.gte(version, '0.2.0')) {
+			} else if (semver.gte(version, '0.2.2')) {
 				eslintResolver = require(eslintResolverPath);
 			} else {
 				eslintResolver = require(path.join(eslintrcPath, '..', '..', '..', 'lib', 'shared', 'relative-module-resolver.js'));

--- a/get-config.js
+++ b/get-config.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const semver = require('semver');
 const {npmGlobalModules, yarnGlobalModules, supportGlobalResolving} = require('./global-resolver');
 
 // Find first parent module from the accessing ESLint.
@@ -29,7 +30,28 @@ function getGlobalConfig({
 		...search.map(dir => path.join(dir, 'eslint', 'lib', 'shared', 'relative-module-resolver.js'))
 	].find(dir => fs.existsSync(dir));
 	if (eslintResolverPath) {
-		supportGlobalResolving(eslintResolverPath, search);
+		let eslintResolver;
+
+		if (eslintResolverPath.includes('eslintrc')) {
+			const eslintrcPath = path.join(eslintResolverPath, '..', '..', '..');
+			const version = require(path.join(eslintrcPath, 'package.json')).version;
+			if (semver.gte(version, '0.4.1')) {
+				const {
+					Legacy: {
+						ModuleResolver
+					}
+				} = require(eslintrcPath);
+				eslintResolver = ModuleResolver;
+			} else if (semver.gte(version, '0.2.0')) {
+				eslintResolver = require(eslintResolverPath);
+			} else {
+				eslintResolver = require(path.join(eslintrcPath, '..', '..', '..', 'lib', 'shared', 'relative-module-resolver.js'));
+			}
+		} else {
+			eslintResolver = require(eslintResolverPath);
+		}
+
+		supportGlobalResolving(eslintResolver, search);
 	}
 	// If eslint/lib/shared/relative-module-resolver.js does not exist, then
 	// our global resolving support cannot be patched in.

--- a/global-resolver.js
+++ b/global-resolver.js
@@ -23,8 +23,7 @@ const npmGlobalModules = () => execSync('npm root -g');
 
 const yarnGlobalModules = () => execSync('yarn global dir');
 
-const supportGlobalResolving = (resolverFile, globalPaths) => {
-	const resolver = require(resolverFile);
+const supportGlobalResolving = (resolver, globalPaths) => {
 	const doResolve = resolver.resolve;
 	if (!Array.isArray(globalPaths)) globalPaths = [globalPaths];
 	resolver.resolve = function(moduleName, relativeToPath) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,5 +1,29 @@
 {
   "name": "eslint-config-enact-proxy",
   "version": "1.0.3",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "scripts": {
     "lint": "eslint .",
     "fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "semver": "^7.3.5"
   }
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
Failed to load config in the latest ESLint version due to the new API change exists.
https://github.com/eslint/eslint/pull/14577

For eslint 8 updating(WRN-12748), we need to modify ModuleResolver calling method.

### Resolution
Applied the new API to call ESLint module resolver correctly with the latest eslint.

### Additional Considerations

### Links
WRN-12748

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)